### PR TITLE
Document debconf interaction with dpkg-reconfigure

### DIFF
--- a/lib/ansible/modules/debconf.py
+++ b/lib/ansible/modules/debconf.py
@@ -35,9 +35,8 @@ notes:
     - The main issue is that the "<package>.config reconfigure" step for many packages will first reset the debconf database (overriding changes made
       by this module) by checking the on-disk configuration. If this is the case for your package then dpkg-reconfigure will effectively ignore changes
       made by debconf.
-    - However as dpkg-reconfigure finally invokes: <---- This line onward are WIP pending a solution.
-    - export DPKG_MAINTSCRIPT_PACKAGE=<package> /usr/share/debconf/frontend /var/lib/dpkg/info/<package>.postinst configure <version> 
-    - to actually configure the package this may be a suitable trigger.
+    - However as dpkg-reconfigure only executes the "<package>.config" step if the file exists, it is possible to move it out of the way before executing
+      "dpkg-reconfigure -f noninteractive <package>". This seems to be compliant with Debian policy for the .config file.
 
 requirements:
 - debconf


### PR DESCRIPTION
It's not obvious at all that dpkg-reconfigure is needed to apply these changes.
Nor is it obvious why in some cases it completely ignores debconf values.

These docs let people understand and potentially dig into scripts to find workarounds.

It would be nice to find a way to invoke the frontend to just execute the postinst configure step.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
